### PR TITLE
Task 7

### DIFF
--- a/infra/lib/product-service-stack/authorization-service-stack.ts
+++ b/infra/lib/product-service-stack/authorization-service-stack.ts
@@ -1,0 +1,37 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as path from 'path';
+
+export class AuthorizationServiceStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // Define the Lambda function for basic authorizer
+    const basicAuthorizerLambda = new lambda.Function(
+      this,
+      'BasicAuthorizerLambda',
+      {
+        runtime: lambda.Runtime.NODEJS_20_X,
+        handler: 'handlers.basicAuthorizer',
+        code: lambda.Code.fromAsset(path.join(__dirname, './')),
+        environment: {
+          ovladova: process.env.TEST_PASSWORD || 'default_password',
+        },
+      },
+    );
+
+    basicAuthorizerLambda.addPermission('APIGatewayInvokePermission', {
+      principal: new iam.ServicePrincipal('apigateway.amazonaws.com'),
+      action: 'lambda:InvokeFunction',
+      sourceArn: `arn:aws:execute-api:${this.region}:${this.account}:os1p4us77g/authorizers/*`, // Update with your API Gateway ARN
+    });
+
+    // Export the Lambda function ARN for use as Authorizer
+    new cdk.CfnOutput(this, 'BasicAuthorizerLambdaArn', {
+      value: basicAuthorizerLambda.functionArn,
+      exportName: 'BasicAuthorizerLambdaArn',
+    });
+  }
+}

--- a/infra/lib/product-service-stack/authorization-service-stack.ts
+++ b/infra/lib/product-service-stack/authorization-service-stack.ts
@@ -17,7 +17,7 @@ export class AuthorizationServiceStack extends cdk.Stack {
         handler: 'handlers.basicAuthorizer',
         code: lambda.Code.fromAsset(path.join(__dirname, './')),
         environment: {
-          ovladova: process.env.TEST_PASSWORD || 'default_password',
+          ovladova: process.env.ovladova || 'TEST_PASSWORD',
         },
       },
     );

--- a/infra/lib/product-service-stack/package-lock.json
+++ b/infra/lib/product-service-stack/package-lock.json
@@ -18,6 +18,7 @@
         "@types/uuid": "^10.0.0",
         "aws-lambda": "^1.0.7",
         "csv-parser": "^3.0.0",
+        "dotenv": "^16.4.5",
         "uuid": "^11.0.2"
       }
     },
@@ -2910,6 +2911,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/es-define-property": {

--- a/infra/lib/product-service-stack/package.json
+++ b/infra/lib/product-service-stack/package.json
@@ -20,6 +20,7 @@
     "@types/uuid": "^10.0.0",
     "aws-lambda": "^1.0.7",
     "csv-parser": "^3.0.0",
+    "dotenv": "^16.4.5",
     "uuid": "^11.0.2"
   }
 }


### PR DESCRIPTION
- ` authorization-service` is added to the repo, has correct `basicAuthorizer` lambda and correct CDK file 

- Import Service CDK file has authorizer configuration for the `importProductsFile` lambda. Request to the `importProductsFile` lambda should work only with correct `authorization_token` being decoded and checked by `basicAuthorizer` lambda. Response should be in 403 HTTP status if access is denied for this user (invalid `authorization_token`) and in 401 HTTP status if Authorization header is not provided.

- Client application is updated to send "Authorization: Basic` authorization_token`" header on import. Client should get `authorization_token` value from browser [localStorage](https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage)